### PR TITLE
removed dist from biome test

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["node_modules"]
+		"ignore": ["node_modules", "dist"]
 	},
 	"formatter": {
 		"enabled": true,


### PR DESCRIPTION
To avoid biome test for builds, the "dist" directory was added to files/ignore list. 