### PR TITLE
Improve CLI Messaging for Python3 Runtime (Alpha) Selection

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nanoctl
 
+## 0.0.16
+
+### Patch Changes
+
+- Add Python3 runtime warning and installation requirement
+
 ## 0.0.15
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nanoctl",
-	"version": "0.0.15",
+	"version": "0.0.16",
 	"author": "Deskree Technologies Inc.",
 	"license": "Apache-2.0",
 	"description": "cli for nanoservice-ts",

--- a/packages/cli/src/commands/create/node.ts
+++ b/packages/cli/src/commands/create/node.ts
@@ -54,7 +54,7 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 						message: "Select the nanoservice runtime",
 						options: [
 							{ label: "Typescript", value: "typescript", hint: "recommended" },
-							{ label: "Python3", value: "python3" },
+							{ label: "Python3", value: "python3", hint: "Alpha - Limited to MacOS and Linux" },
 						],
 					}),
 			},
@@ -68,6 +68,15 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 
 		nodeName = nanoctlNode.nodeName;
 		node_runtime = nanoctlNode.nodeRuntime;
+
+		if (node_runtime === "python3") {
+			// Show a warning message
+			console.log(
+				color.yellow(
+					"⚠️  Python3 runtime is currently in Alpha and is limited to MacOS and Linux. Please use Typescript for production.",
+				),
+			);
+		}
 
 		if (node_runtime !== "python3") {
 			const nanoctlNodeExtension = await p.group(
@@ -218,7 +227,10 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 		}
 
 		if (!isDefault) s.stop(`Node "${nodeName}" created successfully.`);
-		if (!currentPath) console.log(`\nNavigate to the node directory by running: cd src/nodes/${nodeName}`);
+		if (!currentPath && node_runtime === "typescript")
+			console.log(`\nNavigate to the node directory by running: cd src/nodes/${nodeName}`);
+		if (!currentPath && node_runtime === "python3")
+			console.log(`\nNavigate to the node directory by running: cd runtimes/python3/nodes/${nodeName}`);
 		console.log(
 			`${currentPath ? "\n" : ""}Run the command "npm run build" or "npm run build:dev" to build the project.`,
 		);

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -81,6 +81,36 @@ export async function createProject(opts: OptionValues, currentPath = false) {
 						],
 						initialValues: ["node"],
 					}),
+			},
+			{
+				onCancel: () => {
+					p.cancel("Operation canceled.");
+					process.exit(0);
+				},
+			},
+		);
+
+		projectName = nanoctlProject.projectName;
+		trigger = nanoctlProject.trigger;
+		runtimes = nanoctlProject.runtimes;
+
+		// Python3 Alpha Warning
+		if (runtimes.includes("python3")) {
+			// Show a warning message
+			console.log(color.yellow("⚠️  Python3 Runtime (Alpha Version) ⚠️."));
+			console.log(color.yellow("-----------------------------------------------------"));
+
+			console.log(color.yellow("- Requires **Python 3** to be installed."));
+			console.log(color.yellow("- Currently supported only on **MacOS**."));
+			console.log(color.yellow("- Experimental feature: Some functionality may be unstable or missing."));
+			console.log(color.yellow("- Recommended for testing purposes only."));
+			console.log(color.yellow("- For production, use **NodeJS (recommended)**."));
+
+			console.log(color.yellow("-----------------------------------------------------"));
+		}
+
+		const nanoctlExamplesProject = await p.group(
+			{
 				examples: () =>
 					p.select({
 						message: "Install the examples?",
@@ -98,10 +128,7 @@ export async function createProject(opts: OptionValues, currentPath = false) {
 			},
 		);
 
-		projectName = nanoctlProject.projectName;
-		trigger = nanoctlProject.trigger;
-		examples = nanoctlProject.examples;
-		runtimes = nanoctlProject.runtimes;
+		examples = nanoctlExamplesProject.examples;
 	}
 
 	const s = p.spinner();


### PR DESCRIPTION
#### **Description:**  
This PR enhances the **CLI user experience** when selecting the **Python3 (Alpha)** runtime option. Given that Python3 is currently **limited to MacOS and Linux** and **requires manual installation**, this update adds a **clear warning message** to guide users.  

#### **Key Changes:**  
✅ **Added a warning message** when Python3 is selected, informing users that it is an experimental feature.  
✅ **Explicitly stated that Python 3 must be installed** before using this runtime.  
✅ **Styled the output using ANSI escape codes** for better readability in the terminal.  
✅ **Recommended TypeScript as the stable option** for production environments.  

#### **CLI Output (Updated Example)**  
```shell
⚠️  Python3 Runtime (Alpha Version) ⚠️  
-----------------------------------------------------
- Currently supported only on MacOS and Linux.  
- Experimental feature: Some functionality may be unstable or missing.  
- Recommended for testing purposes only.  
- ❗ Requires Python 3 to be installed. ❗  
- For production, use Typescript (recommended).  
-----------------------------------------------------
```

#### **Why this change?**  
🔹 **Improves developer experience** by preventing confusion around the Python3 runtime.  
🔹 **Provides clear installation requirements** to avoid errors when running nanoservice projects.  
🔹 **Encourages best practices** by guiding users toward the stable TypeScript runtime.  