### PR TITLE
Fix: Dynamically Retrieve nanoctl Version in New Project Setup

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nanoctl
 
+## 0.0.17
+
+### Patch Changes
+
+- Dynamically retrieve nanoctl version in new project setup
+
 ## 0.0.16
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nanoctl",
-	"version": "0.0.16",
+	"version": "0.0.17",
 	"author": "Deskree Technologies Inc.",
 	"license": "Apache-2.0",
 	"description": "cli for nanoservice-ts",

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -27,7 +27,7 @@ const options: Partial<SimpleGitOptions> = {
 
 const git: SimpleGit = simpleGit(options);
 
-export async function createProject(opts: OptionValues, currentPath = false) {
+export async function createProject(opts: OptionValues, version: string, currentPath = false) {
 	const isDefault = opts.name !== undefined;
 	let projectName: string = opts.name ? opts.name : "";
 	let trigger = "http";
@@ -236,7 +236,7 @@ export async function createProject(opts: OptionValues, currentPath = false) {
 
 			packageJsonContent.devDependencies = {
 				...packageJsonContent.devDependencies,
-				nanoctl: "^0.0.14",
+				nanoctl: `^${version}`,
 			};
 		}
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,10 +9,11 @@ import { devProject } from "./commands/dev/index.js";
 import { PosthogAnalytics } from "./services/posthog.js";
 import { getPackageVersion } from "./services/utils.js";
 
+const version = await getPackageVersion();
+
 async function main() {
 	try {
 		const program = new Command();
-		const version = await getPackageVersion();
 		const HOME_DIR = `${os.homedir()}/.nanoctl`;
 		const cliConfigPath = `${HOME_DIR}/nanoctl.json`;
 
@@ -36,7 +37,7 @@ async function main() {
 					command: "create project",
 					args: options,
 					execution: async () => {
-						createProject(options, false);
+						createProject(options, version, false);
 					},
 				});
 			});
@@ -49,7 +50,7 @@ async function main() {
 					command: "create project .",
 					args: options,
 					execution: async () => {
-						createProject(options, true);
+						createProject(options, version, true);
 					},
 				});
 			});


### PR DESCRIPTION
#### **Description:**  
This PR **removes the hardcoded `nanoctl` version** in the devDependencies of newly created projects and **replaces it with a dynamic versioning system** that extracts the installed version from `package.json`.  

#### **Key Changes:**  
✅ **Replaced hardcoded `nanoctl` version** in the generated `package.json` for new projects.  
✅ **Dynamically retrieves the CLI version** from `package.json` to ensure consistency.  
✅ **Prevents mismatched versions** when updating `nanoctl`, improving maintainability.  

#### **Why this change?**  
🔹 **Eliminates version inconsistencies** between the CLI and new projects.  
🔹 **Ensures automatic version alignment** when updating `nanoctl`.  
🔹 **Improves long-term maintainability** and avoids potential package conflicts.  