### PR TITLE
Add JavaScript SDK Example Templates during Project Creation

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nanoctl
 
+## 0.0.18
+
+### Patch Changes
+
+- Added JS sdk examples to the project
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nanoctl",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"author": "Deskree Technologies Inc.",
 	"license": "Apache-2.0",
 	"description": "cli for nanoservice-ts",

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -179,6 +179,7 @@ export async function createProject(opts: OptionValues, version: string, current
 		} else {
 			fsExtra.copySync(`${GITHUB_REPO_LOCAL}/infra/development`, `${nodesDir}/examples/infra`);
 			fsExtra.writeFileSync(`${dirPath}/src/Nodes.ts`, node_file);
+			fsExtra.copySync(`${GITHUB_REPO_LOCAL}/sdk`, `${dirPath}/public/sdk`);
 		}
 
 		// Create .env.local file


### PR DESCRIPTION
This PR introduces a new feature to the npx nanoctl@latest create project CLI flow. Now, when a user creates a new nanoservice-ts project, example files demonstrating how to interact with remote nodes using the JavaScript SDK will be automatically added.

**Purpose:**

1. Provide developers with instant working examples of SDK usage.
2. Highlight how nanoservices follow the Single Responsibility Principle (SRP) — each nanoservice is designed to perform one specific task.
3. Accelerate the learning curve by bridging the gap between backend workflows and frontend SDK consumption.
4. Improve overall onboarding experience for both backend and frontend developers.

**Key Updates:**

1. Adds JS SDK example files to the newly created project.
2. Demonstrates calling remote nodes using .nodejs() and .python3() methods.
3. Clear separation of responsibilities: lightweight SDK client code, with all business logic inside nanoservices.
4. Simple examples show how workflows and nanoservices stay modular and easy to maintain.

**Why It Matters:**
This change promotes faster adoption of nanoservice architecture by making it easier to understand the execution model from a JavaScript application point of view — without requiring deep backend or workflow authoring skills.

**Testing Notes:**

Create a project using the CLI.
Verify that the new SDK examples are generated in the project directory "public".
Run the examples against existing workflows to validate the remote execution logic. http://localhost:4000/sdk/javascript/pdf.html

note: you need to configure the ENV vars:
POSTGRESQL_PASSWORD=example
POSTGRESQL_USER=postgres

also run the docker compose file located in the directory: src/nodes/examples/infra

