### PR TITLE
[Roadmap] Extend Cli Commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Project
 
 on:
   push:
-    branches: [ main ]
+    branches: [ feat/login-cli ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Project
 
 on:
   push:
-    branches: [ feat/login-cli ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,0 +1,42 @@
+# Base image with both Python and Node.js
+FROM python:3.11-slim-bookworm
+
+# Install Node.js (LTS version)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Supervisor
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    supervisor \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up working directories
+WORKDIR /app
+COPY . .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r ./.nanoctl/runtimes/python3/requirements.txt
+
+# Install Node.js dependencies
+RUN npm install
+# Build the Node.js application
+RUN npm run build
+
+# Configure Supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Set environment variables
+ENV WORKFLOWS_PATH=/app/workflows
+ENV CONSOLE_LOG_ACTIVE=true
+ENV NODE_ENV=production
+ENV APP_NAME=nanoservice-http
+
+# Expose ports (Node.js on 3000, Python on 8000)
+EXPOSE 4000/tcp
+EXPOSE 9091/tcp
+
+# Start Supervisor
+ENTRYPOINT ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf", "-e", "debug"]

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -1,0 +1,49 @@
+# use the official Bun image
+# see all versions at https://hub.docker.com/r/oven/bun/tags
+FROM oven/bun:1 AS base
+WORKDIR /usr/src/app
+
+# install dependencies into temp directory
+# this will cache them and speed up future builds
+FROM base AS install
+RUN mkdir -p /temp/dev
+COPY package.json /temp/dev/
+RUN cd /temp/dev && bun install --frozen-lockfile
+
+# install with --production (exclude devDependencies)
+RUN mkdir -p /temp/prod
+COPY package.json /temp/prod/
+RUN cd /temp/prod && bun install --frozen-lockfile --production
+
+# copy node_modules from temp directory
+# then copy all (non-ignored) project files into the image
+FROM base AS prerelease
+COPY --from=install /temp/dev/node_modules node_modules
+COPY . .
+
+# [optional] tests & build
+ENV NODE_ENV=production
+# RUN bun add -d @types/ejs
+RUN bun run build
+
+# copy production dependencies and source code into final image
+FROM node:23.6.0-slim AS release
+WORKDIR /usr/src/app
+
+COPY --from=install /temp/prod/node_modules node_modules
+COPY --from=prerelease /usr/src/app/dist dist
+COPY --from=prerelease /usr/src/app/package.json .
+COPY --from=prerelease /usr/src/app/workflows workflows
+
+ENV WORKFLOWS_PATH=/usr/src/app/workflows
+ENV CONSOLE_LOG_ACTIVE=true
+ENV NODE_ENV=production
+ENV APP_NAME=nanoservice-http
+
+# run the app
+USER node
+EXPOSE 4000/tcp
+EXPOSE 9091/tcp
+
+#ENTRYPOINT [ "node", "-r", "./dist/opentelemetry_traces.js", "-r", "./dist/opentelemetry_metrics.js", "dist/index.js" ]
+ENTRYPOINT [ "node", "-r", "./dist/opentelemetry_metrics.js", "dist/index.js" ]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nanoctl",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"author": "Deskree Technologies Inc.",
 	"license": "Apache-2.0",
 	"description": "cli for nanoservice-ts",

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -45,7 +45,7 @@ async function initBuild(opts: OptionValues) {
 }
 
 async function createTarBall(opts: OptionValues) {
-	const fileName = `${crypto.randomUUID()}.tgz`;
+	const fileName = `${crypto.randomUUID()}.tar.gz`;
 	// const command = `npm pack ${opts.directory} --pack-destination ${opts.directory}`;
 	const command = `tar -czf ${opts.directory}/${fileName} -C ${opts.directory} --exclude=${fileName} --exclude=.nanoservice.json --exclude=.git --exclude=node_modules --exclude=package-lock.json --exclude=README.md .`;
 	const execResponse = await exec(command);
@@ -97,7 +97,7 @@ async function getBuildStatus(opts: OptionValues) {
 	return buildStatusData;
 }
 
-async function build(opts: OptionValues) {
+export async function build(opts: OptionValues) {
 	const logger = p.spinner();
 	try {
 		logger.start(`Building nanoservice in ${opts.directory}...`);
@@ -176,8 +176,8 @@ async function build(opts: OptionValues) {
 		if (status?.status?.condition?.status !== "True") throw new Error(status?.status?.condition?.message);
 		logger.stop("Build completed successfully", 0);
 	} catch (error) {
-		logger.stop(`Build Failed. ${error} - Build ID: ${opts.id}`, 1);
-		return;
+		if (opts.id) logger.stop(`Build Failed. ${error} - Build ID: ${opts.id}`, 1);
+		else logger.stop(`Build Failed. ${error}`, 1);
 	}
 }
 

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1,0 +1,210 @@
+import child_process from "node:child_process";
+import util from "node:util";
+import * as p from "@clack/prompts";
+import fs from "fs-extra";
+import { type OptionValues, program, trackCommandExecution } from "../../services/commander.js";
+const exec = util.promisify(child_process.exec);
+
+import { NANOSERVICE_URL } from "../../services/constants.js";
+import { tokenManager } from "../../services/local-token-manager.js";
+
+type StatusType =
+	| {
+			status?: {
+				condition?: {
+					reason?: string;
+					status?: string;
+					message?: string;
+				};
+				startTime?: string;
+				completionTime?: string;
+			};
+	  }
+	| undefined;
+
+const nanoserviceJsonModel = {
+	name: "",
+	builds: [],
+	lastBuild: {},
+	deployments: [],
+	lastDeployment: {},
+};
+
+async function initBuild(opts: OptionValues) {
+	const initBuild = await fetch(`${NANOSERVICE_URL}/build-init`, {
+		method: "GET",
+		headers: {
+			Authorization: `Bearer ${opts.token}`,
+		},
+	});
+	if (!initBuild.ok) throw new Error(initBuild.statusText);
+
+	const initBuildData = await initBuild.json();
+
+	return initBuildData;
+}
+
+async function createTarBall(opts: OptionValues) {
+	const fileName = `${crypto.randomUUID()}.tgz`;
+	// const command = `npm pack ${opts.directory} --pack-destination ${opts.directory}`;
+	const command = `tar -czf ${opts.directory}/${fileName} -C ${opts.directory} --exclude=${fileName} --exclude=.nanoservice.json --exclude=.git --exclude=node_modules --exclude=package-lock.json --exclude=README.md .`;
+	const execResponse = await exec(command);
+	if (execResponse.stderr) throw new Error(`Error creating tarball: ${execResponse.stderr}`);
+
+	return execResponse.stdout !== "" ? execResponse.stdout : fileName;
+}
+
+async function storeFiles(opts: OptionValues) {
+	const file = await fs.readFile(`${opts.directory}/${opts.tarball}`);
+	// const file = await fs.readFile("/Users/ernestochan/Desktop/context.tar.gz");
+	const requestOptions: RequestInit = {
+		method: "PUT",
+		headers: {
+			"Content-Type": "application/x-gzip",
+		},
+		body: file,
+		redirect: "follow",
+	};
+	const storing = await fetch(opts.url, requestOptions);
+	if (!storing.ok) throw new Error("Failed to store file in S3 bucket");
+}
+
+async function building(opts: OptionValues) {
+	const build = await fetch(`${NANOSERVICE_URL}/build/${opts.id}`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${opts.token}`,
+		},
+		body: JSON.stringify({
+			key: opts.key,
+		}),
+	});
+	if (!build.ok) throw new Error(build.statusText);
+	const buildData = await build.json();
+	return buildData;
+}
+
+async function getBuildStatus(opts: OptionValues) {
+	const buildStatus = await fetch(`${NANOSERVICE_URL}/build-status/${opts.id}`, {
+		method: "GET",
+		headers: {
+			Authorization: `Bearer ${opts.token}`,
+		},
+	});
+	if (!buildStatus.ok) throw new Error(buildStatus.statusText);
+	const buildStatusData = await buildStatus.json();
+	return buildStatusData;
+}
+
+async function build(opts: OptionValues) {
+	const logger = p.spinner();
+	try {
+		logger.start(`Building nanoservice in ${opts.directory}...`);
+		// get token
+		logger.message("Validating authentication...");
+		opts.token = tokenManager.getToken();
+		if (!opts.token) throw new Error("No token found. Please login first.");
+
+		// check if the directory is a nanoservice
+		const nanoserviceFile = `${opts.directory}/.nanoservice.json`;
+
+		// Check if the directory exists
+		logger.message("Checking files...");
+		if (!fs.existsSync(opts.directory)) throw new Error(`Directory ${opts.directory} does not exist`);
+		if (!fs.existsSync(`${opts.directory}/Dockerfile`)) throw new Error(`Dockerfile not found in ${opts.directory}`);
+		if (!fs.existsSync(nanoserviceFile)) {
+			fs.ensureFileSync(nanoserviceFile);
+			fs.writeJSONSync(nanoserviceFile, nanoserviceJsonModel, { spaces: 2 });
+			logger.message("Creating .nanoservice.json file...");
+		}
+
+		logger.message("Loading .nanoservice.json file...");
+		const json = fs.readJSONSync(nanoserviceFile);
+
+		// Compressing the directory
+		logger.message("Creating tarball...");
+		opts.tarball = await createTarBall(opts);
+		fs.ensureFileSync(opts.tarball);
+		logger.message("Tarball created");
+
+		// call init
+		logger.message("Initializing build...");
+		const init = await initBuild(opts);
+		opts.id = init.id;
+		opts.url = init.data.url;
+		opts.key = init.data.key;
+		logger.message("Build initialized");
+
+		// call store
+		logger.message("Storing files...");
+		await storeFiles(opts);
+		fs.removeSync(opts.tarball);
+		logger.message("Files stored");
+
+		// call build
+		logger.message("Building nanoservice...");
+		const build = await building(opts);
+
+		// Check build status
+		let status: StatusType;
+		do {
+			await new Promise((resolve) => setTimeout(resolve, 2000));
+			status = await getBuildStatus(opts);
+			logger.message(status?.status?.condition?.reason ?? "Unknown reason");
+		} while (status?.status?.condition?.status === "Unknown");
+
+		// Store the build result
+		logger.message("Storing build result...");
+		const initBuildModel = {
+			id: opts.id,
+			tarball: opts.tarball,
+			key: opts.key,
+			buildMessage: build.data.message,
+			creationTimestamp: build.data.creationTimestamp,
+			startTime: status?.status?.startTime,
+			completionTime: status?.status?.completionTime,
+			reason: status?.status?.condition?.reason,
+			status: status?.status?.condition?.status,
+			statusMessage: status?.status?.condition?.message,
+			updatedAt: new Date().toISOString(),
+		};
+		json.builds.push(initBuildModel);
+		json.lastBuild = initBuildModel;
+		fs.writeJSONSync(nanoserviceFile, json, { spaces: 2 });
+
+		if (status?.status?.condition?.status !== "True") throw new Error(status?.status?.condition?.message);
+		logger.stop("Build completed successfully", 0);
+	} catch (error) {
+		logger.stop(`Build Failed. ${error} - Build ID: ${opts.id}`, 1);
+		return;
+	}
+}
+
+const buildCmd = program
+	.command("build")
+	.option("-d, --directory [value]", "Directory of the nanoservice (defaults to current directory)", process.cwd())
+	.description("Build nanoservice")
+	.action(async (options: OptionValues) => {
+		await trackCommandExecution({
+			command: "build",
+			args: options,
+			execution: async () => {
+				await build(options);
+			},
+		});
+	});
+
+buildCmd
+	.command(".")
+	.description("Build nanoservice in the current directory")
+	.action(async (options: OptionValues) => {
+		await trackCommandExecution({
+			command: "build .",
+			args: options,
+			execution: async () => {
+				options.directory = process.cwd();
+				await build(options);
+			},
+		});
+	});

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -56,7 +56,6 @@ async function createTarBall(opts: OptionValues) {
 
 async function storeFiles(opts: OptionValues) {
 	const file = await fs.readFile(`${opts.directory}/${opts.tarball}`);
-	// const file = await fs.readFile("/Users/ernestochan/Desktop/context.tar.gz");
 	const requestOptions: RequestInit = {
 		method: "PUT",
 		headers: {
@@ -151,7 +150,7 @@ export async function build(opts: OptionValues) {
 		do {
 			await new Promise((resolve) => setTimeout(resolve, 2000));
 			status = await getBuildStatus(opts);
-			logger.message(status?.status?.condition?.reason ?? "Unknown reason");
+			logger.message(`Build ${status?.status?.condition?.reason}`);
 		} while (status?.status?.condition?.status === "Unknown");
 
 		// Store the build result
@@ -176,8 +175,10 @@ export async function build(opts: OptionValues) {
 		if (status?.status?.condition?.status !== "True") throw new Error(status?.status?.condition?.message);
 		logger.stop("Build completed successfully", 0);
 	} catch (error) {
+		if (opts.tarball && fs.existsSync(opts.tarball)) fs.removeSync(opts.tarball);
 		if (opts.id) logger.stop(`Build Failed. ${error} - Build ID: ${opts.id}`, 1);
 		else logger.stop(`Build Failed. ${error}`, 1);
+		console.error(error);
 	}
 }
 

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -47,7 +47,7 @@ async function initBuild(opts: OptionValues) {
 async function createTarBall(opts: OptionValues) {
 	const fileName = `${crypto.randomUUID()}.tar.gz`;
 	// const command = `npm pack ${opts.directory} --pack-destination ${opts.directory}`;
-	const command = `tar -czf ${opts.directory}/${fileName} -C ${opts.directory} --exclude=${fileName} --exclude=.nanoservice.json --exclude=.git --exclude=node_modules --exclude=package-lock.json --exclude=README.md .`;
+	const command = `tar -czf ${opts.directory}/${fileName} -C ${opts.directory} --exclude=${fileName} --exclude=.nanoservice.json --exclude=.git --exclude=node_modules --exclude=package-lock.json --exclude=README.md --exclude=.nanoctl/runtimes/python3/python3_runtime/lib .`;
 	const execResponse = await exec(command);
 	if (execResponse.stderr) throw new Error(`Error creating tarball: ${execResponse.stderr}`);
 

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -174,11 +174,13 @@ export async function build(opts: OptionValues) {
 
 		if (status?.status?.condition?.status !== "True") throw new Error(status?.status?.condition?.message);
 		logger.stop("Build completed successfully", 0);
+		return true;
 	} catch (error) {
 		if (opts.tarball && fs.existsSync(opts.tarball)) fs.removeSync(opts.tarball);
 		if (opts.id) logger.stop(`Build Failed. ${error} - Build ID: ${opts.id}`, 1);
 		else logger.stop(`Build Failed. ${error}`, 1);
 		console.error(error);
+		return false;
 	}
 }
 

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -138,6 +138,9 @@ export async function createProject(opts: OptionValues, version: string, current
 		// Prepare the project
 		const dirPath = !currentPath ? path.join(process.cwd(), projectName) : process.cwd();
 
+		// Add permissions to the directory
+		fsExtra.chmodSync(dirPath, 0o755);
+
 		if (!isDefault) s.message("Gathering project files");
 
 		const githubLocalExists = fsExtra.existsSync(GITHUB_REPO_LOCAL);

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -138,9 +138,6 @@ export async function createProject(opts: OptionValues, version: string, current
 		// Prepare the project
 		const dirPath = !currentPath ? path.join(process.cwd(), projectName) : process.cwd();
 
-		// Add permissions to the directory
-		fsExtra.chmodSync(dirPath, 0o755);
-
 		if (!isDefault) s.message("Gathering project files");
 
 		const githubLocalExists = fsExtra.existsSync(GITHUB_REPO_LOCAL);
@@ -169,6 +166,9 @@ export async function createProject(opts: OptionValues, version: string, current
 
 		fsExtra.ensureDirSync(nodesDir);
 		fsExtra.copySync(`${GITHUB_REPO_LOCAL}/workflows`, workflowsDir);
+
+		// Add permissions to the directory
+		fsExtra.chmodSync(dirPath, 0o755);
 
 		// Examples
 

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -9,7 +9,14 @@ import figlet from "figlet";
 import fsExtra from "fs-extra";
 import color from "picocolors";
 import simpleGit, { type SimpleGit, type SimpleGitOptions } from "simple-git";
-import { examples_url, node_file, package_dependencies, package_dev_dependencies } from "./utils/Examples.js";
+import {
+	examples_url,
+	node_file,
+	package_dependencies,
+	package_dev_dependencies,
+	supervisord_nodejs,
+	supervisord_python,
+} from "./utils/Examples.js";
 
 const exec = util.promisify(child_process.exec);
 
@@ -168,7 +175,7 @@ export async function createProject(opts: OptionValues, version: string, current
 		fsExtra.copySync(`${GITHUB_REPO_LOCAL}/workflows`, workflowsDir);
 
 		// Add permissions to the directory
-		fsExtra.chmodSync(dirPath, 0o755);
+		fsExtra.chownSync(dirPath, os.userInfo().uid, os.userInfo().gid);
 
 		// Examples
 
@@ -257,6 +264,12 @@ export async function createProject(opts: OptionValues, version: string, current
 		}
 
 		fsExtra.writeFileSync(packageJson, JSON.stringify(packageJsonContent, null, 2));
+
+		// Create supervisord.conf
+		const supervisordConfPath = `${dirPath}/supervisord.conf`;
+		let supervisordConfContent = supervisord_nodejs;
+		if (runtimes.includes("python3")) supervisordConfContent += supervisord_python;
+		fsExtra.writeFileSync(supervisordConfPath, supervisordConfContent);
 
 		// Install Packages
 		s.message("Installing packages...");

--- a/packages/cli/src/commands/create/utils/Examples.ts
+++ b/packages/cli/src/commands/create/utils/Examples.ts
@@ -99,4 +99,35 @@ const workflow_template = `
 }
 `;
 
-export { node_file, package_dependencies, package_dev_dependencies, python3_file, examples_url, workflow_template };
+const supervisord_nodejs = `
+[supervisord]
+nodaemon=true
+
+[program:nodejs_app]
+command=npm start
+directory=/app
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/nodejs.err.log
+stdout_logfile=/var/log/nodejs.out.log
+`;
+
+const supervisord_python = `
+[program:python_app]
+command=python3 /app/.nanoctl/runtimes/python3/server.py
+directory=/app
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/python.err.log
+stdout_logfile=/var/log/python.out.log
+`;
+export {
+	node_file,
+	package_dependencies,
+	package_dev_dependencies,
+	python3_file,
+	examples_url,
+	workflow_template,
+	supervisord_nodejs,
+	supervisord_python,
+};

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -102,13 +102,17 @@ export async function deploy(opts: OptionValues) {
 		// Check deployment status
 		let isReady = false;
 		let deploymentStatus: StatusType = {};
+		let errorCount = 0;
 		do {
 			logger.message("Deploying...");
 			await new Promise((resolve) => setTimeout(resolve, 2000));
 			deploymentStatus = await getDeploymentStatus(opts);
 			isReady = true;
 			for (const condition of deploymentStatus?.conditions || []) {
-				if (condition.reason) throw new Error(condition.message);
+				if (condition.reason) {
+					errorCount++;
+					if (errorCount > 3) throw new Error(condition.message);
+				}
 				if (condition.status !== "True") {
 					isReady = false;
 					break;

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -1,20 +1,128 @@
 import * as p from "@clack/prompts";
+import fs from "fs-extra";
 import { type OptionValues, program, trackCommandExecution } from "../../services/commander.js";
 
-// import { tokenManager } from "../../services/local-token-manager.js";
+import { NANOSERVICE_URL } from "../../services/constants.js";
+import { tokenManager } from "../../services/local-token-manager.js";
+
+import { build as buildCommand } from "../build/index.js";
 
 async function deploy(opts: OptionValues) {
-	p.log.success("deploy command executed");
+	const logger = p.spinner();
+	try {
+		logger.start("Deploying nanoservice...");
+		// check if the directory is a nanoservice
+		const nanoserviceFile = `${opts.directory}/.nanoservice.json`;
+
+		// Check if the directory exists
+		logger.message("Checking files...");
+		if (!fs.existsSync(opts.directory)) throw new Error(`Directory ${opts.directory} does not exist`);
+		if (!fs.existsSync(nanoserviceFile)) throw new Error(`.nanoservice.json file not found in ${opts.directory}`);
+
+		logger.message("Loading .nanoservice.json file...");
+		const json = fs.readJSONSync(nanoserviceFile);
+
+		// Validating the nanoservice name
+		if (!json.name || json.name === "") {
+			json.name = opts.name;
+			fs.writeJSONSync(nanoserviceFile, json, { spaces: 2 });
+			logger.message(`Updated .nanoservice.json name to ${opts.name}`);
+		} else {
+			if (json.name !== opts.name) {
+				logger.message(`.nanoservice.json name is ${json.name}, but you provided ${opts.name}`);
+				const confirm = await p.confirm({
+					message: `Do you want to update the name in .nanoservice.json to ${opts.name}?`,
+					initialValue: false,
+				});
+				if (!confirm) throw new Error("Aborting deployment");
+				json.name = opts.name;
+				fs.writeJSONSync(nanoserviceFile, json, { spaces: 2 });
+				logger.message(`Updated .nanoservice.json name to ${opts.name}`);
+			}
+		}
+
+		// getting last build id
+		if (!json.lastBuild) throw new Error("No last build found. Please build first.");
+		if (!json.lastBuild.id) throw new Error("No last build id found. Please build first.");
+		opts.id = json.lastBuild.id;
+
+		// get token
+		logger.message("Validating authentication...");
+		opts.token = tokenManager.getToken();
+		if (!opts.token) throw new Error("No token found. Please login first.");
+
+		logger.message("Deployment started...");
+		const deployment = await fetch(`${NANOSERVICE_URL}/deploy/${opts.id}`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${opts.token}`,
+			},
+			body: JSON.stringify({
+				serviceName: opts.name,
+			}),
+		});
+		if (!deployment.ok) throw new Error(deployment.statusText);
+		const deploymentData = await deployment.json();
+		if (deploymentData.error) throw new Error(deploymentData.error);
+
+		// Update .nanoservice.json with deployment results
+		logger.message("Updating .nanoservice.json with deployment results...");
+		json.deployments = json.deployments || [];
+		json.deployments.push(deploymentData);
+		json.lastDeployment = deploymentData;
+		fs.writeJSONSync(nanoserviceFile, json, { spaces: 2 });
+
+		logger.message("Deployment completed");
+		logger.stop("Nanoservice deployed successfully!");
+	} catch (error) {
+		logger.stop(`Error: ${error}`, 1);
+	}
 }
 
-program
+const deployCmd = program
 	.command("deploy")
 	.description("Deploy nanoservice")
+	.requiredOption("-n, --name <name>", "Name of the nanoservice")
+	.option("--build", "Build before deploying", () => true)
+	.option("-d, --directory [value]", "Directory of the nanoservice (defaults to current directory)", process.cwd())
 	.action(async (options: OptionValues) => {
+		if (options.build) {
+			await trackCommandExecution({
+				command: "deploy --build",
+				args: options,
+				execution: async () => {
+					await buildCommand(options);
+				},
+			});
+		}
 		await trackCommandExecution({
 			command: "deploy",
 			args: options,
 			execution: async () => {
+				await deploy(options);
+			},
+		});
+	});
+
+deployCmd
+	.command(".")
+	.description("Deploy nanoservice in the current directory")
+	.action(async (options: OptionValues) => {
+		if (options.build) {
+			await trackCommandExecution({
+				command: "deploy . --build",
+				args: options,
+				execution: async () => {
+					await buildCommand(options);
+				},
+			});
+		}
+		await trackCommandExecution({
+			command: "deploy .",
+			args: options,
+			execution: async () => {
+				options.directory = process.cwd();
 				await deploy(options);
 			},
 		});

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -36,7 +36,7 @@ async function getDeploymentStatus(opts: OptionValues): Promise<StatusType> {
 	return deploymentStatusData.data;
 }
 
-async function deploy(opts: OptionValues) {
+export async function deploy(opts: OptionValues) {
 	const logger = p.spinner();
 	try {
 		logger.start("Deploying nanoservice...");
@@ -127,8 +127,10 @@ async function deploy(opts: OptionValues) {
 			0,
 		);
 		p.log.success(`Service live at: ${color.greenBright(deploymentData?.data?.url)}`);
+		return true;
 	} catch (error) {
 		logger.stop(`Error: ${error}`, 1);
+		return false;
 	}
 }
 

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -11,6 +11,8 @@ import { build as buildCommand } from "../build/index.js";
 type StatusType = {
 	conditions?: Array<{
 		type?: string;
+		reason?: string;
+		message?: string;
 		status?: string;
 		lastTransitionTime?: string;
 	}>;
@@ -106,6 +108,7 @@ export async function deploy(opts: OptionValues) {
 			deploymentStatus = await getDeploymentStatus(opts);
 			isReady = true;
 			for (const condition of deploymentStatus?.conditions || []) {
+				if (condition.reason) throw new Error(condition.message);
 				if (condition.status !== "True") {
 					isReady = false;
 					break;

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -1,0 +1,21 @@
+import * as p from "@clack/prompts";
+import { type OptionValues, program, trackCommandExecution } from "../../services/commander.js";
+
+// import { tokenManager } from "../../services/local-token-manager.js";
+
+async function deploy(opts: OptionValues) {
+	p.log.success("deploy command executed");
+}
+
+program
+	.command("deploy")
+	.description("Deploy nanoservice")
+	.action(async (options: OptionValues) => {
+		await trackCommandExecution({
+			command: "deploy",
+			args: options,
+			execution: async () => {
+				await deploy(options);
+			},
+		});
+	});

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -1,0 +1,64 @@
+import * as p from "@clack/prompts";
+import type { OptionValues } from "commander";
+
+import { tokenManager } from "../../services/local-token-manager.js";
+
+export async function login(opts: OptionValues) {
+	let token = tokenManager.getToken();
+	const NANOSERVICES_TOKEN = process.env.NANOSERVICES_TOKEN as string;
+
+	const resolveTokenType = async (): Promise<string> => {
+		const tokenType = await p.select({
+			message: "Choose the authentication method",
+			options: [
+				{ value: "token", label: "Provide token manually", hint: "Recommended" },
+				{ value: "token", label: "Authenticate via web", hint: "Comming soon" },
+			],
+		});
+
+		if (p.isCancel(tokenType)) {
+			p.cancel("Authentiecation cancelled.");
+			process.exit(0);
+		}
+
+		return tokenType;
+	};
+
+	const resolveToken = async (): Promise<string> => {
+		let token = process.env.NANOSERVICES_TOKEN;
+		if (token) return token;
+		token = (await p.password({
+			message:
+				"Please provide the token for authentication. You can create it on https://atomic.deskree.com/auth/access/token",
+		})) as string;
+
+		if (p.isCancel(token)) {
+			p.cancel("Authentication cancelled.");
+			process.exit(0);
+		}
+
+		return token;
+	};
+
+	try {
+		if (!token && !NANOSERVICES_TOKEN && !opts.token) {
+			const tokenType = await resolveTokenType();
+			if (tokenType === "token") token = await resolveToken();
+		} else if (opts.token) {
+			token = opts.token;
+		} else if (NANOSERVICES_TOKEN) {
+			token = NANOSERVICES_TOKEN;
+		}
+
+		p.log.success("Login successful.");
+		if (!token) throw new Error("NANOSERVICES_TOKEN is required.");
+
+		const isStored = tokenManager.storeToken(token);
+		if (!isStored) throw new Error("Failed to store the token.");
+		p.log.info("You can now use the CLI commands. For help, run: nanoctl --help");
+	} catch (error) {
+		p.log.error("Login failed. Please try again.");
+		p.log.error((error as Error).message);
+		process.exit(1);
+	}
+}

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -7,22 +7,22 @@ export async function login(opts: OptionValues) {
 	let token = tokenManager.getToken();
 	const NANOSERVICES_TOKEN = process.env.NANOSERVICES_TOKEN as string;
 
-	const resolveTokenType = async (): Promise<string> => {
-		const tokenType = await p.select({
-			message: "Choose the authentication method",
-			options: [
-				{ value: "token", label: "Provide token manually", hint: "Recommended" },
-				{ value: "token", label: "Authenticate via web", hint: "Comming soon" },
-			],
-		});
+	// const resolveTokenType = async (): Promise<string> => {
+	// 	const tokenType = await p.select({
+	// 		message: "Choose the authentication method",
+	// 		options: [
+	// 			{ value: "token", label: "Provide token manually", hint: "Recommended" },
+	// 			{ value: "token", label: "Authenticate via web", hint: "Comming soon" },
+	// 		],
+	// 	});
 
-		if (p.isCancel(tokenType)) {
-			p.cancel("Authentiecation cancelled.");
-			process.exit(0);
-		}
+	// 	if (p.isCancel(tokenType)) {
+	// 		p.cancel("Authentiecation cancelled.");
+	// 		process.exit(0);
+	// 	}
 
-		return tokenType;
-	};
+	// 	return tokenType;
+	// };
 
 	const resolveToken = async (): Promise<string> => {
 		let token = process.env.NANOSERVICES_TOKEN;
@@ -42,8 +42,9 @@ export async function login(opts: OptionValues) {
 
 	try {
 		if (!token && !NANOSERVICES_TOKEN && !opts.token) {
-			const tokenType = await resolveTokenType();
-			if (tokenType === "token") token = await resolveToken();
+			// const tokenType = await resolveTokenType();
+			// if (tokenType === "token")
+			token = await resolveToken();
 		} else if (opts.token) {
 			token = opts.token;
 		} else if (NANOSERVICES_TOKEN) {

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import type { OptionValues } from "commander";
+import { type OptionValues, program, trackCommandExecution } from "../../services/commander.js";
 
 import { tokenManager } from "../../services/local-token-manager.js";
 
@@ -62,3 +62,18 @@ export async function login(opts: OptionValues) {
 		process.exit(1);
 	}
 }
+
+// Login command
+program
+	.command("login")
+	.description("Login to Nanoservices")
+	.option("-t, --token <value>", "Login with a token")
+	.action(async (options: OptionValues) => {
+		await trackCommandExecution({
+			command: "login",
+			args: options,
+			execution: async () => {
+				await login(options);
+			},
+		});
+	});

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -1,0 +1,15 @@
+import child_process from "node:child_process";
+import util from "node:util";
+import * as p from "@clack/prompts";
+import type { OptionValues } from "commander";
+
+import { tokenManager } from "../../services/local-token-manager.js";
+
+const exec = util.promisify(child_process.exec);
+
+export async function logout(opts: OptionValues) {
+	tokenManager.clearToken();
+	exec("unset NANOSERVICES_TOKEN");
+	p.log.success("Logged out successfully.");
+	p.log.info("You can log in again using: nanoctl login");
+}

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -1,15 +1,10 @@
-import child_process from "node:child_process";
-import util from "node:util";
 import * as p from "@clack/prompts";
 import type { OptionValues } from "commander";
 
 import { tokenManager } from "../../services/local-token-manager.js";
 
-const exec = util.promisify(child_process.exec);
-
 export async function logout(opts: OptionValues) {
 	tokenManager.clearToken();
-	exec("unset NANOSERVICES_TOKEN");
 	p.log.success("Logged out successfully.");
 	p.log.info("You can log in again using: nanoctl login");
 }

--- a/packages/cli/src/commands/logout/index.ts
+++ b/packages/cli/src/commands/logout/index.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import type { OptionValues } from "commander";
+import { type OptionValues, program, trackCommandExecution } from "../../services/commander.js";
 
 import { tokenManager } from "../../services/local-token-manager.js";
 
@@ -8,3 +8,17 @@ export async function logout(opts: OptionValues) {
 	p.log.success("Logged out successfully.");
 	p.log.info("You can log in again using: nanoctl login");
 }
+
+// Logout command
+program
+	.command("logout")
+	.description("Logout from Nanoservices")
+	.action(async (options: OptionValues) => {
+		await trackCommandExecution({
+			command: "logout",
+			args: options,
+			execution: async () => {
+				await logout(options);
+			},
+		});
+	});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,8 @@ import { createNode } from "./commands/create/node.js";
 import { createProject } from "./commands/create/project.js";
 import { createWorkflow } from "./commands/create/workflow.js";
 import { devProject } from "./commands/dev/index.js";
+import { login } from "./commands/login/index.js";
+import { logout } from "./commands/logout/index.js";
 import { PosthogAnalytics } from "./services/posthog.js";
 import { getPackageVersion } from "./services/utils.js";
 
@@ -124,6 +126,35 @@ async function main() {
 					args: options,
 					execution: async () => {
 						devProject(options);
+					},
+				});
+			});
+
+		// Login command
+		program
+			.command("login")
+			.description("Login to Nanoservices")
+			.option("-t, --token <value>", "Login with a token")
+			.action(async (options: OptionValues) => {
+				await analytics.trackCommandExecution({
+					command: "login",
+					args: options,
+					execution: async () => {
+						await login(options);
+					},
+				});
+			});
+
+		// Logout command
+		program
+			.command("logout")
+			.description("Logout from Nanoservices")
+			.action(async (options: OptionValues) => {
+				await analytics.trackCommandExecution({
+					command: "logout",
+					args: options,
+					execution: async () => {
+						await logout(options);
 					},
 				});
 			});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -154,7 +154,13 @@ async function main() {
 					command: "logout",
 					args: options,
 					execution: async () => {
-						await logout(options);
+						await analytics.trackCommandExecution({
+							command: "logout",
+							args: options,
+							execution: async () => {
+								await logout(options);
+							},
+						});
 					},
 				});
 			});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,21 +1,24 @@
 #! /usr/bin/env node
 import os from "node:os";
-import { Command, type OptionValues } from "commander";
 import fsExtra from "fs-extra";
 import { createNode } from "./commands/create/node.js";
 import { createProject } from "./commands/create/project.js";
 import { createWorkflow } from "./commands/create/workflow.js";
 import { devProject } from "./commands/dev/index.js";
-import { login } from "./commands/login/index.js";
-import { logout } from "./commands/logout/index.js";
+import { type OptionValues, program } from "./services/commander.js";
 import { PosthogAnalytics } from "./services/posthog.js";
 import { getPackageVersion } from "./services/utils.js";
+
+// Commands
+import "./commands/login/index.js";
+import "./commands/logout/index.js";
+import "./commands/build/index.js";
+import "./commands/deploy/index.js";
 
 const version = await getPackageVersion();
 
 async function main() {
 	try {
-		const program = new Command();
 		const HOME_DIR = `${os.homedir()}/.nanoctl`;
 		const cliConfigPath = `${HOME_DIR}/nanoctl.json`;
 
@@ -126,41 +129,6 @@ async function main() {
 					args: options,
 					execution: async () => {
 						devProject(options);
-					},
-				});
-			});
-
-		// Login command
-		program
-			.command("login")
-			.description("Login to Nanoservices")
-			.option("-t, --token <value>", "Login with a token")
-			.action(async (options: OptionValues) => {
-				await analytics.trackCommandExecution({
-					command: "login",
-					args: options,
-					execution: async () => {
-						await login(options);
-					},
-				});
-			});
-
-		// Logout command
-		program
-			.command("logout")
-			.description("Logout from Nanoservices")
-			.action(async (options: OptionValues) => {
-				await analytics.trackCommandExecution({
-					command: "logout",
-					args: options,
-					execution: async () => {
-						await analytics.trackCommandExecution({
-							command: "logout",
-							args: options,
-							execution: async () => {
-								await logout(options);
-							},
-						});
 					},
 				});
 			});

--- a/packages/cli/src/services/commander.ts
+++ b/packages/cli/src/services/commander.ts
@@ -1,0 +1,31 @@
+import os from "node:os";
+import { Command, type OptionValues } from "commander";
+import { PosthogAnalytics } from "./posthog.js";
+import { getPackageVersion } from "./utils.js";
+
+const version = await getPackageVersion();
+const program = new Command();
+
+const HOME_DIR = `${os.homedir()}/.nanoctl`;
+const cliConfigPath = `${HOME_DIR}/nanoctl.json`;
+
+const analytics = new PosthogAnalytics({
+	version: version,
+	cliConfigPath: cliConfigPath,
+});
+
+type TrackCommandExecutionParams = {
+	command: string;
+	args: OptionValues;
+	execution: () => Promise<void>;
+};
+
+const trackCommandExecution = async ({ command, args, execution }: TrackCommandExecutionParams) => {
+	await analytics.trackCommandExecution({
+		command: command,
+		args: args,
+		execution,
+	});
+};
+
+export { program, trackCommandExecution, type OptionValues, type TrackCommandExecutionParams };

--- a/packages/cli/src/services/constants.ts
+++ b/packages/cli/src/services/constants.ts
@@ -1,0 +1,1 @@
+export const NANOSERVICE_URL = "https://runner.dac-us-east-1.deskree.com/public/deployment";

--- a/packages/cli/src/services/constants.ts
+++ b/packages/cli/src/services/constants.ts
@@ -1,1 +1,1 @@
-export const NANOSERVICE_URL = "http://localhost:4001";
+export const NANOSERVICE_URL = "https://runner.dac-us-east-1.deskree.com/public/deployment";

--- a/packages/cli/src/services/constants.ts
+++ b/packages/cli/src/services/constants.ts
@@ -1,1 +1,1 @@
-export const NANOSERVICE_URL = "https://runner.dac-us-east-1.deskree.com/public/deployment";
+export const NANOSERVICE_URL = "http://localhost:4001";

--- a/packages/cli/src/services/local-token-manager.ts
+++ b/packages/cli/src/services/local-token-manager.ts
@@ -1,0 +1,113 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+class LocalTokenManager {
+	private storageDir: string;
+	private tokenFile: string;
+
+	constructor() {
+		// Set up secure storage directory
+		this.storageDir = path.join(os.homedir(), ".nanoctl/token");
+		this.tokenFile = path.join(this.storageDir, "token.enc");
+
+		// Ensure storage directory exists with proper permissions
+		this.ensureStorage();
+	}
+
+	private ensureStorage() {
+		try {
+			// Create directory if it doesn't exist (with secure permissions)
+			if (!fs.existsSync(this.storageDir)) {
+				fs.mkdirSync(this.storageDir, { mode: 0o700 }); // rwx for owner only
+			} else {
+				// Fix existing directory permissions if needed
+				fs.chmodSync(this.storageDir, 0o700);
+			}
+
+			// Create empty token file if it doesn't exist (with secure permissions)
+			if (!fs.existsSync(this.tokenFile)) {
+				fs.writeFileSync(this.tokenFile, "", { mode: 0o600 }); // rw for owner only
+			} else {
+				// Fix existing file permissions if needed
+				fs.chmodSync(this.tokenFile, 0o600);
+			}
+		} catch (error) {
+			console.error("Failed to initialize secure storage:", (error as Error).message);
+			throw new Error("Could not set up secure token storage, please check permissions.");
+		}
+	}
+
+	private getEncryptionKey() {
+		// In production, you should get this from a more secure source
+		// For local development, we'll derive it from machine ID + salt
+		const machineId = os.hostname();
+		const salt = crypto
+			.createHash("sha256")
+			.update(os.userInfo().username + os.arch() + os.platform())
+			.digest("hex");
+		return crypto.scryptSync(machineId + salt, "salt", 32);
+	}
+
+	private encrypt(text: string): string {
+		const iv: Buffer = crypto.randomBytes(16);
+		const cipher: crypto.CipherGCM = crypto.createCipheriv("aes-256-gcm", this.getEncryptionKey(), iv);
+		let encrypted: string = cipher.update(text, "utf8", "hex");
+		encrypted += cipher.final("hex");
+		const authTag: string = cipher.getAuthTag().toString("hex");
+		return `${iv.toString("hex")}:${authTag}:${encrypted}`;
+	}
+
+	private decrypt(encryptedText: string): string {
+		const parts = encryptedText.split(":");
+		if (parts.length !== 3) {
+			throw new Error("Invalid encrypted text format");
+		}
+		const [ivHex, authTagHex, encrypted]: [string, string, string] = parts as [string, string, string];
+		const iv: Buffer = Buffer.from(ivHex, "hex");
+		const authTag: Buffer = Buffer.from(authTagHex, "hex");
+		const decipher: crypto.DecipherGCM = crypto.createDecipheriv("aes-256-gcm", this.getEncryptionKey(), iv);
+		decipher.setAuthTag(authTag);
+		let decrypted: string = decipher.update(encrypted, "hex", "utf8");
+		decrypted += decipher.final("utf8");
+		return decrypted;
+	}
+
+	storeToken(token: string): boolean {
+		try {
+			const encrypted: string = this.encrypt(token);
+			fs.writeFileSync(this.tokenFile, encrypted, { mode: 0o600 }); // rw only for owner
+			return true;
+		} catch (error: unknown) {
+			console.error("Failed to store token:", (error as Error).message);
+			return false;
+		}
+	}
+
+	getToken() {
+		try {
+			if (!fs.existsSync(this.tokenFile)) return null;
+			const encrypted = fs.readFileSync(this.tokenFile, "utf8");
+			return this.decrypt(encrypted);
+		} catch (error) {
+			return null;
+		}
+	}
+
+	clearToken() {
+		try {
+			if (fs.existsSync(this.tokenFile)) {
+				fs.unlinkSync(this.tokenFile);
+			}
+			return true;
+		} catch (error) {
+			console.error("Failed to clear token:", (error as Error).message);
+			return false;
+		}
+	}
+}
+
+// Singleton instance
+const tokenManager = new LocalTokenManager();
+export { LocalTokenManager, tokenManager };

--- a/packages/cli/src/services/utils.ts
+++ b/packages/cli/src/services/utils.ts
@@ -11,5 +11,5 @@ export async function getPackageVersion() {
 	const pkgJsonPath = path.join(__dirname, "..", "..", "package.json");
 
 	const content = (await fs.readJSON(pkgJsonPath)) as PackageJson;
-	return content.version as string;
+	return content?.version as string;
 }

--- a/packages/cli/tests/commands/build/build.test.ts
+++ b/packages/cli/tests/commands/build/build.test.ts
@@ -1,0 +1,51 @@
+import fs from "fs-extra";
+import { expect, test, vi } from "vitest";
+import { build } from "../../../src/commands/build";
+import { tokenManager } from "../../../src/services/local-token-manager.js";
+import * as utils from "../../../src/services/utils.js";
+
+vi.mock("fs-extra");
+vi.mock("../../../src/services/local-token-manager.js");
+vi.mock("../../../src/services/constants.js", () => ({
+	NANOSERVICE_URL: "http://mock-nanoservice-url.com",
+}));
+
+test("build - successful build", async () => {
+	vi.spyOn(fs, "existsSync").mockImplementation((path) => {
+		if (String(path).includes("Dockerfile") || String(path).includes(".nanoservice.json")) return true;
+		return false;
+	});
+	vi.spyOn(fs, "readJSONSync").mockReturnValue({});
+	vi.spyOn(fs, "writeJSONSync").mockImplementation(() => {});
+	vi.spyOn(fs, "ensureFileSync").mockImplementation(() => {});
+	vi.spyOn(fs, "removeSync").mockImplementation(() => {});
+	vi.spyOn(tokenManager, "getToken").mockReturnValue("mock-token");
+	vi.spyOn(utils, "getPackageVersion").mockResolvedValue("1.0.0");
+
+	await expect(build({ directory: "test" })).resolves.not.toThrow();
+});
+
+test("build - missing directory", async () => {
+	vi.spyOn(fs, "existsSync").mockReturnValue(false);
+
+	await expect(build({ directory: "missing-dir" })).resolves.toBeFalsy();
+});
+
+test("build - missing Dockerfile", async () => {
+	vi.spyOn(fs, "existsSync").mockImplementation((path) => {
+		if (String(path).includes("Dockerfile")) return false;
+		return true;
+	});
+
+	await expect(build({ directory: "test" })).resolves.toBeFalsy();
+});
+
+test("build - authentication failure", async () => {
+	vi.spyOn(fs, "existsSync").mockImplementation((path) => {
+		if (String(path).includes("Dockerfile") || String(path).includes(".nanoservice.json")) return true;
+		return false;
+	});
+	vi.spyOn(tokenManager, "getToken").mockReturnValue(null);
+
+	await expect(build({ directory: "test" })).resolves.toBeFalsy();
+});

--- a/packages/cli/tests/commands/deploy/deploy.test.ts
+++ b/packages/cli/tests/commands/deploy/deploy.test.ts
@@ -1,0 +1,121 @@
+import * as p from "@clack/prompts";
+import fs from "fs-extra";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deploy } from "../../../src/commands/deploy";
+import { tokenManager } from "../../../src/services/local-token-manager.js";
+
+vi.mock("fs-extra");
+vi.mock("@clack/prompts");
+vi.mock("../../../../src/services/local-token-manager.js");
+vi.mock("../../../../src/services/constants.js", () => ({
+	NANOSERVICE_URL: "https://mock-nanoservice-url.com",
+}));
+vi.mock("node-fetch", () => ({
+	default: vi.fn(),
+}));
+
+const fetch = (await import("node-fetch")).default;
+
+describe("deploy command", () => {
+	interface DeployOptions {
+		name: string;
+		directory: string;
+	}
+
+	let opts: DeployOptions = {
+		name: "test-service",
+		directory: "/mock/directory",
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		opts = {
+			name: "test-service",
+			directory: "/mock/directory",
+		};
+	});
+
+	it("should deploy successfully", async () => {
+		vi.spyOn(fs, "existsSync").mockImplementation((path) => {
+			if (String(path).includes("Dockerfile") || String(path).includes(".nanoservice.json")) return true;
+			return false;
+		});
+		vi.spyOn(fs, "readJSONSync").mockReturnValue({
+			name: "test-service",
+			lastBuild: { id: "123", reason: "Succeeded" },
+		});
+		vi.spyOn(fs, "writeJSONSync").mockImplementation(() => {});
+		vi.spyOn(fs, "ensureFileSync").mockImplementation(() => {});
+		vi.spyOn(fs, "removeSync").mockImplementation(() => {});
+		vi.spyOn(tokenManager, "getToken").mockReturnValue("mock-token");
+		vi.spyOn(fs, "writeJSONSync").mockImplementation(() => {});
+		vi.spyOn(fs, "readJSONSync").mockImplementation(() => ({
+			name: "test-service",
+			lastBuild: { id: "123", reason: "Succeeded" },
+		}));
+		vi.spyOn(p, "spinner").mockReturnValue({
+			start: vi.fn(),
+			message: vi.fn(),
+			stop: vi.fn(),
+		});
+		vi.spyOn(tokenManager, "getToken").mockReturnValue("mock-token");
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ data: { url: "https://mock-service-url.com" } }),
+		});
+		fetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				data: {
+					conditions: [{ status: "True" }],
+					latestReadyRevisionName: "v1",
+				},
+			}),
+		});
+
+		await deploy(opts);
+	});
+
+	it("should throw an error if .nanoservice.json is missing", async () => {
+		vi.spyOn(fs, "existsSync").mockImplementation((path) => {
+			if (String(path).includes("Dockerfile")) return true;
+			if (String(path).includes(".nanoservice.json")) return false;
+			return false;
+		});
+		vi.spyOn(fs, "readJSONSync").mockReturnValue({
+			name: "test-service",
+			lastBuild: { id: "123", reason: "Succeeded" },
+		});
+		vi.spyOn(tokenManager, "getToken").mockReturnValue("mock-token");
+		vi.spyOn(fs, "writeJSONSync").mockImplementation(() => {});
+		vi.spyOn(fs, "ensureFileSync").mockImplementation(() => {});
+		vi.spyOn(fs, "removeSync").mockImplementation(() => {});
+		vi.spyOn(p, "spinner").mockReturnValue({
+			start: vi.fn(),
+			message: vi.fn(),
+			stop: vi.fn(),
+		});
+
+		await expect(deploy(opts)).resolves.toBeFalsy();
+	});
+
+	it("should throw an error if token is missing", async () => {
+		vi.spyOn(fs, "existsSync").mockImplementation((path) => {
+			if (String(path).includes("Dockerfile")) return true;
+			if (String(path).includes(".nanoservice.json")) return false;
+			return false;
+		});
+		vi.spyOn(p, "spinner").mockReturnValue({
+			start: vi.fn(),
+			message: vi.fn(),
+			stop: vi.fn(),
+		});
+		vi.spyOn(fs, "readJSONSync").mockReturnValue({
+			name: "test-service",
+			lastBuild: { id: "123", reason: "Succeeded" },
+		});
+		vi.spyOn(tokenManager, "getToken").mockReturnValue("mock-token");
+
+		await expect(deploy(opts)).resolves.toBeFalsy();
+	});
+});

--- a/packages/cli/tests/commands/login/login.test.ts
+++ b/packages/cli/tests/commands/login/login.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+import { login } from "../../../src/commands/login";
+
+test("login", async () => {
+	expect(async () => await login({ token: "test" })).not.toThrow();
+});

--- a/packages/cli/tests/commands/logout/logout.test.ts
+++ b/packages/cli/tests/commands/logout/logout.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+import { logout } from "../../../src/commands/logout";
+
+test("logout", async () => {
+	expect(async () => await logout({ token: "test" })).not.toThrow();
+});

--- a/triggers/http/Dockerfile
+++ b/triggers/http/Dockerfile
@@ -1,49 +1,42 @@
-# use the official Bun image
-# see all versions at https://hub.docker.com/r/oven/bun/tags
-FROM oven/bun:1 AS base
-WORKDIR /usr/src/app
+# Base image with both Python and Node.js
+FROM python:3.11-slim-bookworm
 
-# install dependencies into temp directory
-# this will cache them and speed up future builds
-FROM base AS install
-RUN mkdir -p /temp/dev
-COPY package.json /temp/dev/
-RUN cd /temp/dev && bun install --frozen-lockfile
+# Install Node.js (LTS version)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
-# install with --production (exclude devDependencies)
-RUN mkdir -p /temp/prod
-COPY package.json /temp/prod/
-RUN cd /temp/prod && bun install --frozen-lockfile --production
+# Install Supervisor
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    supervisor \
+    && rm -rf /var/lib/apt/lists/*
 
-# copy node_modules from temp directory
-# then copy all (non-ignored) project files into the image
-FROM base AS prerelease
-COPY --from=install /temp/dev/node_modules node_modules
+# Set up working directories
+WORKDIR /app
 COPY . .
 
-# [optional] tests & build
-ENV NODE_ENV=production
-# RUN bun add -d @types/ejs
-RUN bun run build
+# Install Python dependencies
+RUN pip install --no-cache-dir -r ./.nanoctl/runtimes/python3/requirements.txt
 
-# copy production dependencies and source code into final image
-FROM node:23.6.0-slim AS release
-WORKDIR /usr/src/app
+# Install Node.js dependencies
+RUN npm install
+# Build the Node.js application
+RUN npm run build
 
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /usr/src/app/dist dist
-COPY --from=prerelease /usr/src/app/package.json .
-COPY --from=prerelease /usr/src/app/workflows workflows
+# Configure Supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-ENV WORKFLOWS_PATH=/usr/src/app/workflows
+# Set environment variables
+ENV WORKFLOWS_PATH=/app/workflows
 ENV CONSOLE_LOG_ACTIVE=true
 ENV NODE_ENV=production
 ENV APP_NAME=nanoservice-http
 
-# run the app
-USER node
+# Expose ports (Node.js on 3000, Python on 8000)
 EXPOSE 4000/tcp
 EXPOSE 9091/tcp
 
-#ENTRYPOINT [ "node", "-r", "./dist/opentelemetry_traces.js", "-r", "./dist/opentelemetry_metrics.js", "dist/index.js" ]
-ENTRYPOINT [ "node", "-r", "./dist/opentelemetry_metrics.js", "dist/index.js" ]
+# Start Supervisor
+ENTRYPOINT ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf", "-e", "debug"]

--- a/triggers/http/notes/CLI_Commands/Authentication.md
+++ b/triggers/http/notes/CLI_Commands/Authentication.md
@@ -1,0 +1,74 @@
+# NanoCTL Login Command
+
+## Table of Contents
+
+1. [Authentication Methods](#authentication-methods)  
+    - [Environment Variable](#1-environment-variable)  
+    - [Token Flag](#2-token-flag)  
+    - [Interactive Prompt](#3-interactive-prompt)  
+2. [How to Logout](#how-to-logout)  
+
+## Authentication Methods
+
+### 1. Environment Variable
+   - **Best for**: Automated environments, CI/CD pipelines
+
+        **Usage**:
+        ```bash
+        export NANOSERVICES_TOKEN="your_api_token_here"
+        npx nanoctl@latest login
+        ```
+
+        **Behavior**:
+        - Automatically detects `NANOSERVICES_TOKEN` from the environment.
+        - Non-interactive - runs silently.
+        - Returns exit code `0` on success, non-zero on failure.
+        - Token is not stored locally (uses the environment variable each time).
+        
+### 2. Token Flag
+   - **Best for**: Temporary sessions, quick testing
+
+        **Usage**:
+        ```bash
+        npx nanoctl@latest login --token "your_api_token_here"
+        npx nanoctl@latest login -t "your_api_token_here"
+        ```
+
+        **Behavior**:
+        - Immediately authenticates with the provided token.
+        - Token is not saved to disk.
+        - Shows authentication result message.
+        - Recommended to wrap the token in quotes to prevent shell history logging.
+
+### 3. Interactive Prompt
+  - **Best for**: First-time setup, most secure local use
+    **Usage**:
+    ```bash
+    npx nanoctl@latest login
+    ```
+
+    **Interactive Flow**:
+    - **Command launches prompt**:
+    ```bash
+    ◆ Please provide the token for authentication. You can create it on https://atomic.deskree.com/auth/access/token █
+    ```
+    Input is masked while typing.
+    - **Token is validated immediately**:
+        - **On success**:
+            - Token is encrypted and stored.
+            - Displays welcome message with username and expiration date.
+        - **On failure**:
+            - Shows specific error (e.g., invalid token, network issue).
+
+
+## How to logout
+
+```bash
+npx nanoctl@latest logout
+```
+
+Removes the authentication token from the local machine.
+
+This function is used to delete the stored token, ensuring that 
+the user is logged out or the token is no longer accessible 
+from the current environment.

--- a/triggers/http/notes/CLI_Commands/Building.md
+++ b/triggers/http/notes/CLI_Commands/Building.md
@@ -1,0 +1,52 @@
+# NanoService CLI Commands: Build
+
+## Table of Contents
+- [Build Nanoservice](#build-nanoservice)
+  - [Syntax](#build-syntax)
+  - [Options](#build-options)
+  - [Examples](#build-examples)
+- [Deploy Nanoservice](#deploy-nanoservice)
+  - [Syntax](#deploy-syntax)
+  - [Options](#deploy-options)
+  - [Examples](#deploy-examples)
+- [Common Examples](#common-examples)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Build Nanoservice
+
+### Syntax
+```bash
+npx nanoctl build [options]
+```
+  Compiles and packages a nanoservice from source code into a deployable artifact.
+ 
+  ### Options
+  | Option       | Alias | Type    | Description                | Default            |
+  |--------------|-------|---------|----------------------------|--------------------|
+  | `--directory`| `-d`  | string  | Source directory path      | `./nanoservice-ts` |
+  | `--help`     | `-h`  | boolean | Show help                  | `false`            |
+ 
+  ### Commands
+  | Command | Description               |
+  |---------|---------------------------|
+  | `.`     | Build in current directory|
+ 
+  ### Examples
+  #### Build in default directory:
+  ``` bash
+  npx nanoctl build
+  ```
+  #### Build in specific directory:
+  ```bash
+  npx nanoctl build -d ./my-nanoservice
+  ```
+
+  #### Build in current directory:
+  ```bash
+  npx nanoctl build .
+  ```
+
+---
+> **Note**: After executing the building command, you can proceed to deploy the nanoservice using the [deploy](./Deployment.md) command.

--- a/triggers/http/notes/CLI_Commands/Deployment.md
+++ b/triggers/http/notes/CLI_Commands/Deployment.md
@@ -1,0 +1,69 @@
+# NanoService CLI Commands
+
+## Table of Contents
+
+---
+
+## Deploy Nanoservice
+
+### Syntax
+```bash
+npx nanoctl deploy [options]
+```
+
+
+ Deploys a nanoservice to the NanoServices platform, optionally building it first.
+ *
+ Options:
+ - `--name`, `-n` (string): Service name (required). Default: none.
+ - `--build` (boolean): Build before deploying. Default: false.
+ - `--directory`, `-d` (string): Source directory path. Default: Current working directory.
+ - `--help`, `-h` (boolean): Show help. Default: false.
+ *
+ Commands:
+ - `.`: Deploy from the current directory.
+
+### Examples
+
+#### Deploy with build:
+```bash
+npx nanoctl deploy -n my-service --build
+```
+
+#### Deploy existing build:
+```bash
+npx nanoctl deploy -n my-service -d ./build-output
+```
+
+#### Deploy from current directory:
+```bash
+npx nanoctl deploy -n my-service .
+```
+
+<br />
+<br />
+<br />
+
+---
+# Build and Deploy Example
+
+#### Build and deploy workflow:
+```bash
+# Build first
+npx nanoctl build -d ./src
+
+# Then deploy
+npx nanoctl deploy -n my-service -d ./src
+```
+
+#### Single-command build & deploy:
+```bash
+npx nanoctl deploy -n my-service --build
+```
+
+#### CI/CD Pipeline Example:
+```bash
+# In your deployment script
+npx nanoctl build -d $CODE_DIR
+npx nanoctl deploy -n $SERVICE_NAME -d $CODE_DIR
+```

--- a/triggers/http/notes/index.md
+++ b/triggers/http/notes/index.md
@@ -46,3 +46,6 @@ Now that you understand the basics, dive deeper into `nanoservice-ts` with the f
 - [Creating Workflows](./CLI_Commands/Create_Workflow.md)  
 - [Creating Custom Nodes](./CLI_Commands/Create_Node.md)
 - [Examples](./examples.md)
+- [Authentication](./CLI_Commands/Authentication.md)
+- [Building](./CLI_Commands/Building.md)
+- [Deployment](./CLI_Commands/Deployment.md)


### PR DESCRIPTION
## Pull Request Title
Add CLI Commands: login, logout, build, deploy

---

## Description
This PR introduces core CLI commands for authentication (login/logout) and deployment (build/deploy). Includes tests and documentation.

---

## Related Issues
Closes #111 

---

## Changes Made
Adds core CLI commands (login, logout, build, deploy) to enable authentication and deployment workflows.

---

## Checklist
- [X] login: Authenticates users and stores session credentials.

- [X] logout: Clears active sessions and credentials.

- [X] build: Compiles the project into deployable artifacts.

- [X] deploy: Publishes artifacts to the target environment.

- [X] Unit tests for all new commands.

- [X] Basic documentation (help flags, usage examples).

---

## Notes
- Authentication uses an access token from https://atomic.deskree.com/auth/access/token

---

Thank you for your contribution!
