### PR TITLE
Apb 433 roadmap validate and prioritize package manager pnpm yarn npm

### DIFF
--- a/packages/cli/src/commands/create/node.ts
+++ b/packages/cli/src/commands/create/node.ts
@@ -16,7 +16,8 @@ const HOME_DIR = `${os.homedir()}/.nanoctl`;
 const GITHUB_REPO_LOCAL = `${HOME_DIR}/nanoservice-ts`;
 
 export async function createNode(opts: OptionValues, currentPath = false) {
-	const manager = await pm.getManager();
+	const availableManagers = await pm.getAvailableManagers();
+	let manager = await pm.getManager();
 	const isDefault = opts.name !== undefined;
 	let nodeName: string = opts.name ? opts.name : "";
 	let nodeType = "";
@@ -168,6 +169,18 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 				packageJsonContent.version = "1.0.0";
 				packageJsonContent.author = "";
 				fsExtra.writeFileSync(packageJson, JSON.stringify(packageJsonContent, null, 2));
+
+				if (availableManagers.length > 1) {
+					s.message("Multiple package managers detected. Please select one.");
+					const selectedManager = await p.select({
+						message: "Select the package manager",
+						options: availableManagers.map((manager) => ({
+							label: manager,
+							value: manager,
+						})),
+					});
+					manager = await pm.getManager(selectedManager as string);
+				}
 
 				// Install Packages
 				s.message("Installing packages...");

--- a/packages/cli/src/commands/create/node.ts
+++ b/packages/cli/src/commands/create/node.ts
@@ -238,7 +238,6 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 		);
 		console.log("For more documentation, visit https://nanoservice.xyz/docs/d/core-concepts/nodes");
 	} catch (error) {
-		console.log(error);
 		if (!isDefault) s.stop("An error occurred");
 
 		const message = (error as Error).message;

--- a/packages/cli/src/commands/create/node.ts
+++ b/packages/cli/src/commands/create/node.ts
@@ -7,6 +7,7 @@ import type { OptionValues } from "commander";
 import figlet from "figlet";
 import fsExtra from "fs-extra";
 import color from "picocolors";
+import { manager as pm } from "../../services/package-manager.js";
 import { python3_file } from "./utils/Examples.js";
 
 const exec = util.promisify(child_process.exec);
@@ -15,6 +16,7 @@ const HOME_DIR = `${os.homedir()}/.nanoctl`;
 const GITHUB_REPO_LOCAL = `${HOME_DIR}/nanoservice-ts`;
 
 export async function createNode(opts: OptionValues, currentPath = false) {
+	const manager = await pm.getManager();
 	const isDefault = opts.name !== undefined;
 	let nodeName: string = opts.name ? opts.name : "";
 	let nodeType = "";
@@ -169,11 +171,11 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 
 				// Install Packages
 				s.message("Installing packages...");
-				await exec("npm install", { cwd: dirPath });
+				await exec(`${manager} install`, { cwd: dirPath });
 
 				// Build the project
 				s.message("Building the project...");
-				await exec("npm run build", { cwd: dirPath });
+				await exec(`${manager} run build`, { cwd: dirPath });
 			}
 
 			if (nodeType === "class") {

--- a/packages/cli/src/commands/create/node.ts
+++ b/packages/cli/src/commands/create/node.ts
@@ -171,11 +171,11 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 
 				// Install Packages
 				s.message("Installing packages...");
-				await exec(`${manager} install`, { cwd: dirPath });
+				await exec(manager.INSTALL, { cwd: dirPath });
 
 				// Build the project
 				s.message("Building the project...");
-				await exec(`${manager} run build`, { cwd: dirPath });
+				await exec(manager.BUILD, { cwd: dirPath });
 			}
 
 			if (nodeType === "class") {
@@ -238,6 +238,7 @@ export async function createNode(opts: OptionValues, currentPath = false) {
 		);
 		console.log("For more documentation, visit https://nanoservice.xyz/docs/d/core-concepts/nodes");
 	} catch (error) {
+		console.log(error);
 		if (!isDefault) s.stop("An error occurred");
 
 		const message = (error as Error).message;

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -36,7 +36,8 @@ const options: Partial<SimpleGitOptions> = {
 const git: SimpleGit = simpleGit(options);
 
 export async function createProject(opts: OptionValues, version: string, currentPath = false) {
-	const manager = await pm.getManager();
+	const availableManagers = await pm.getAvailableManagers();
+	let manager = await pm.getManager();
 	const isDefault = opts.name !== undefined;
 	let projectName: string = opts.name ? opts.name : "";
 	let trigger = "http";
@@ -218,6 +219,19 @@ export async function createProject(opts: OptionValues, version: string, current
 		packageJsonContent.name = projectName;
 		packageJsonContent.version = "1.0.0";
 		packageJsonContent.author = "";
+
+		// Get the package manager
+		if (availableManagers.length > 1) {
+			s.message("Multiple package managers detected. Please select one.");
+			const selectedManager = await p.select({
+				message: "Select the package manager",
+				options: availableManagers.map((manager) => ({
+					label: manager,
+					value: manager,
+				})),
+			});
+			manager = await pm.getManager(selectedManager as string);
+		}
 
 		// Runtimes
 

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -9,6 +9,7 @@ import figlet from "figlet";
 import fsExtra from "fs-extra";
 import color from "picocolors";
 import simpleGit, { type SimpleGit, type SimpleGitOptions } from "simple-git";
+import { manager as pm } from "../../services/package-manager.js";
 import {
 	examples_url,
 	node_file,
@@ -35,6 +36,7 @@ const options: Partial<SimpleGitOptions> = {
 const git: SimpleGit = simpleGit(options);
 
 export async function createProject(opts: OptionValues, version: string, currentPath = false) {
+	const manager = await pm.getManager();
 	const isDefault = opts.name !== undefined;
 	let projectName: string = opts.name ? opts.name : "";
 	let trigger = "http";
@@ -240,7 +242,7 @@ export async function createProject(opts: OptionValues, version: string, current
 
 			// Install Python3 Packages
 			s.message("Installing python3 packages...");
-			await exec("npm install", { cwd: pythonDir });
+			await exec(`${manager} install`, { cwd: pythonDir });
 			await createPythonVenv(pythonDir);
 			await exec(
 				`bash -c "source ${pythonDir}/python3_runtime/bin/activate && pip3 install -r ${pythonDir}/requirements.txt"`,
@@ -283,7 +285,7 @@ export async function createProject(opts: OptionValues, version: string, current
 
 		// Install Packages
 		s.message("Installing packages...");
-		await exec("npm install", { cwd: dirPath });
+		await exec(`${manager} install`, { cwd: dirPath });
 
 		// Create a new project
 		if (!isDefault) s.stop(`Project "${projectName}" created successfully.`);

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -33,6 +33,12 @@ const options: Partial<SimpleGitOptions> = {
 	trimmed: false,
 };
 
+type SpinnerHandler = {
+	start: (msg?: string) => void;
+	stop: (msg?: string, code?: number) => void;
+	message: (msg?: string) => void;
+};
+
 const git: SimpleGit = simpleGit(options);
 
 export async function createProject(opts: OptionValues, version: string, currentPath = false) {
@@ -43,6 +49,7 @@ export async function createProject(opts: OptionValues, version: string, current
 	let trigger = "http";
 	let examples = false;
 	let runtimes = ["node"];
+	let selectedManager = "npm";
 
 	if (!isDefault) {
 		console.log(
@@ -71,6 +78,19 @@ export async function createProject(opts: OptionValues, version: string, current
 			})) as string;
 		};
 
+		const resolveSelectedManager = async (): Promise<string> => {
+			if (availableManagers.length === 1) {
+				return availableManagers[0];
+			}
+			return (await p.select({
+				message: "Select the package manager",
+				options: availableManagers.map((manager) => ({
+					label: manager,
+					value: manager,
+				})),
+			})) as string;
+		};
+
 		const nanoctlProject = await p.group(
 			{
 				projectName: () => resolveProjectName(),
@@ -91,6 +111,7 @@ export async function createProject(opts: OptionValues, version: string, current
 						],
 						initialValues: ["node"],
 					}),
+				selectedManager: () => resolveSelectedManager(),
 			},
 			{
 				onCancel: () => {
@@ -103,10 +124,12 @@ export async function createProject(opts: OptionValues, version: string, current
 		projectName = nanoctlProject.projectName;
 		trigger = nanoctlProject.trigger;
 		runtimes = nanoctlProject.runtimes;
+		selectedManager = nanoctlProject.selectedManager;
 
 		// Python3 Alpha Warning
 		if (runtimes.includes("python3")) {
 			// Show a warning message
+			console.log("");
 			console.log(color.yellow("⚠️  Python3 Runtime (Alpha Version) ⚠️."));
 			console.log(color.yellow("-----------------------------------------------------"));
 
@@ -222,14 +245,6 @@ export async function createProject(opts: OptionValues, version: string, current
 
 		// Get the package manager
 		if (availableManagers.length > 1) {
-			s.message("Multiple package managers detected. Please select one.");
-			const selectedManager = await p.select({
-				message: "Select the package manager",
-				options: availableManagers.map((manager) => ({
-					label: manager,
-					value: manager,
-				})),
-			});
 			manager = await pm.getManager(selectedManager as string);
 		}
 
@@ -254,14 +269,21 @@ export async function createProject(opts: OptionValues, version: string, current
 			fsExtra.symlinkSync(`${pythonDir}/core`, `${pythonProjectDir}/core`, "junction");
 			fsExtra.symlinkSync(`${pythonDir}/requirement.txt`, `${pythonProjectDir}/requirement.txt`, "file");
 
+			// Create a virtual environment
+			s.message("Creating Python3 virtual environment...");
+			await createPythonVenv(pythonDir, s);
+			s.message("Python3 virtual environment created successfully!");
+
 			// Install Python3 Packages
-			s.message("Installing python3 packages...");
 			await exec(manager.INSTALL, { cwd: pythonDir });
-			await createPythonVenv(pythonDir);
-			await exec(
+
+			s.message("Installing python3 packages...");
+			const cmd_install_pythonpk_response = await exec(
 				`bash -c "source ${pythonDir}/python3_runtime/bin/activate && pip3 install -r ${pythonDir}/requirements.txt"`,
 				{ cwd: pythonDir },
 			);
+			s.message("Python3 packages installed successfully!");
+			console.log("\n", cmd_install_pythonpk_response.stdout);
 
 			fsExtra.symlinkSync(`${pythonDir}/python3_runtime`, `${pythonProjectDir}/python3_runtime`, "junction");
 
@@ -299,7 +321,13 @@ export async function createProject(opts: OptionValues, version: string, current
 
 		// Install Packages
 		s.message("Installing packages...");
-		await exec(manager.INSTALL, { cwd: dirPath });
+		const cmd_install_ts_response = await exec(manager.INSTALL, { cwd: dirPath });
+		s.message("Packages installed successfully!");
+		console.log("\n", cmd_install_ts_response.stdout);
+
+		if (!fsExtra.existsSync(`${dirPath}/node_modules`)) {
+			throw new Error("Failed to install packages. Please check your internet connection and try again.");
+		}
 
 		// Create a new project
 		if (!isDefault) s.stop(`Project "${projectName}" created successfully.`);
@@ -318,7 +346,7 @@ export async function createProject(opts: OptionValues, version: string, current
 	}
 }
 
-function createPythonVenv(pythonProjectDir: string): Promise<void> {
+function createPythonVenv(pythonProjectDir: string, s: SpinnerHandler): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const process = spawn("python3", ["-m", "venv", "python3_runtime"], {
 			cwd: pythonProjectDir,
@@ -328,7 +356,7 @@ function createPythonVenv(pythonProjectDir: string): Promise<void> {
 
 		process.on("close", (code) => {
 			if (code === 0) {
-				console.log("\n✅ Python3 virtual environment created successfully!");
+				s.message("Python3 virtual environment created successfully!");
 				resolve();
 			} else {
 				reject(new Error(`❌ Failed to create virtual environment. Exit code: ${code}`));

--- a/packages/cli/src/commands/create/project.ts
+++ b/packages/cli/src/commands/create/project.ts
@@ -242,7 +242,7 @@ export async function createProject(opts: OptionValues, version: string, current
 
 			// Install Python3 Packages
 			s.message("Installing python3 packages...");
-			await exec(`${manager} install`, { cwd: pythonDir });
+			await exec(manager.INSTALL, { cwd: pythonDir });
 			await createPythonVenv(pythonDir);
 			await exec(
 				`bash -c "source ${pythonDir}/python3_runtime/bin/activate && pip3 install -r ${pythonDir}/requirements.txt"`,
@@ -285,7 +285,7 @@ export async function createProject(opts: OptionValues, version: string, current
 
 		// Install Packages
 		s.message("Installing packages...");
-		await exec(`${manager} install`, { cwd: dirPath });
+		await exec(manager.INSTALL, { cwd: dirPath });
 
 		// Create a new project
 		if (!isDefault) s.stop(`Project "${projectName}" created successfully.`);

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -54,7 +54,7 @@ export async function deploy(opts: OptionValues) {
 		const json = fs.readJSONSync(nanoserviceFile);
 
 		// Validate name with regex, should allow letters and dashes only without numbers
-		const nameRegex = /^[a-zA-Z](?:[a-zA-Z-]*[a-zA-Z])?$/;
+		const nameRegex = /^[a-z](?:[a-z-]*[a-z])?$/;
 		if (!nameRegex.test(opts.name))
 			throw new Error(`Invalid name ${opts.name}. Name should only contain letters and dashes.`);
 

--- a/packages/cli/src/services/package-manager.ts
+++ b/packages/cli/src/services/package-manager.ts
@@ -13,6 +13,10 @@ type PackageManagerType = {
 };
 
 const COMMANDS: PackageManagerType = {
+	bun: {
+		INSTALL: "bun install",
+		BUILD: "bun run build",
+	},
 	pnpm: {
 		INSTALL: "pnpm install",
 		BUILD: "pnpm run build",
@@ -45,7 +49,6 @@ class PackageManager {
 		const checkCmd = isWindows ? `where ${cmd}` : `which ${cmd}`;
 		try {
 			await executor(checkCmd);
-			console.log(`Using package manager: ${cmd}`);
 			return true;
 		} catch {
 			return false;

--- a/packages/cli/src/services/package-manager.ts
+++ b/packages/cli/src/services/package-manager.ts
@@ -7,6 +7,27 @@ const PACKAGE_MANAGERS = ["pnpm", "yarn", "npm"]; // Priority order
 
 const isWindows = process.platform === "win32";
 
+type PackageManagerType = {
+	[key: string]: {
+		INSTALL: string;
+		BUILD: string;
+	};
+};
+const COMMANDS: PackageManagerType = {
+	pnpm: {
+		INSTALL: "pnpm install",
+		BUILD: "pnpm run build",
+	},
+	yarn: {
+		INSTALL: "yarn install",
+		BUILD: "yarn run build",
+	},
+	npm: {
+		INSTALL: "npm install",
+		BUILD: "npm run build",
+	},
+};
+
 class PackageManager {
 	private static instance: PackageManager;
 	private detectedManager: string | null = null;
@@ -24,19 +45,20 @@ class PackageManager {
 		const checkCmd = isWindows ? `where ${cmd}` : `which ${cmd}`;
 		try {
 			await executor(checkCmd);
+			console.log(`Using package manager: ${cmd}`);
 			return true;
 		} catch {
 			return false;
 		}
 	}
 
-	public async getManager(): Promise<string> {
-		if (this.detectedManager) return this.detectedManager;
+	public async getManager(): Promise<PackageManagerType[string]> {
+		if (this.detectedManager) return COMMANDS[this.detectedManager];
 
 		for (const manager of PACKAGE_MANAGERS) {
 			if (await this.isAvailable(manager)) {
 				this.detectedManager = manager;
-				return manager;
+				return COMMANDS[manager];
 			}
 		}
 

--- a/packages/cli/src/services/package-manager.ts
+++ b/packages/cli/src/services/package-manager.ts
@@ -1,0 +1,48 @@
+import { exec as _exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const executor = promisify(_exec);
+
+const PACKAGE_MANAGERS = ["pnpm", "yarn", "npm"]; // Priority order
+
+class PackageManager {
+	private static instance: PackageManager;
+	private detectedManager: string | null = null;
+
+	private constructor() {}
+
+	public static getInstance(): PackageManager {
+		if (!PackageManager.instance) {
+			PackageManager.instance = new PackageManager();
+		}
+		return PackageManager.instance;
+	}
+
+	private async isAvailable(cmd: string): Promise<boolean> {
+		try {
+			await executor(`command -v ${cmd}`, { cwd: process.cwd() });
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	public async getManager(): Promise<string> {
+		if (this.detectedManager) return this.detectedManager;
+
+		for (const manager of PACKAGE_MANAGERS) {
+			if (await this.isAvailable(manager)) {
+				this.detectedManager = manager;
+				return manager;
+			}
+		}
+
+		throw new Error("No supported package manager found.");
+	}
+}
+
+export default PackageManager;
+
+const manager = PackageManager.getInstance();
+
+export { manager };

--- a/packages/cli/src/services/package-manager.ts
+++ b/packages/cli/src/services/package-manager.ts
@@ -5,6 +5,8 @@ const executor = promisify(_exec);
 
 const PACKAGE_MANAGERS = ["pnpm", "yarn", "npm"]; // Priority order
 
+const isWindows = process.platform === "win32";
+
 class PackageManager {
 	private static instance: PackageManager;
 	private detectedManager: string | null = null;
@@ -19,8 +21,9 @@ class PackageManager {
 	}
 
 	private async isAvailable(cmd: string): Promise<boolean> {
+		const checkCmd = isWindows ? `where ${cmd}` : `which ${cmd}`;
 		try {
-			await executor(`command -v ${cmd}`, { cwd: process.cwd() });
+			await executor(checkCmd);
 			return true;
 		} catch {
 			return false;

--- a/packages/cli/src/services/package-manager.ts
+++ b/packages/cli/src/services/package-manager.ts
@@ -3,8 +3,6 @@ import { promisify } from "node:util";
 
 const executor = promisify(_exec);
 
-const PACKAGE_MANAGERS = ["pnpm", "yarn", "npm"]; // Priority order
-
 const isWindows = process.platform === "win32";
 
 type PackageManagerType = {
@@ -13,6 +11,7 @@ type PackageManagerType = {
 		BUILD: string;
 	};
 };
+
 const COMMANDS: PackageManagerType = {
 	pnpm: {
 		INSTALL: "pnpm install",
@@ -27,6 +26,7 @@ const COMMANDS: PackageManagerType = {
 		BUILD: "npm run build",
 	},
 };
+const PACKAGE_MANAGERS = Object.keys(COMMANDS);
 
 class PackageManager {
 	private static instance: PackageManager;
@@ -52,7 +52,18 @@ class PackageManager {
 		}
 	}
 
-	public async getManager(): Promise<PackageManagerType[string]> {
+	public async getAvailableManagers(): Promise<string[]> {
+		const availableManagers: string[] = [];
+		for (const manager of PACKAGE_MANAGERS) {
+			if (await this.isAvailable(manager)) {
+				availableManagers.push(manager);
+			}
+		}
+		return availableManagers;
+	}
+
+	public async getManager(preferedManager?: string): Promise<PackageManagerType[string]> {
+		if (preferedManager) return COMMANDS[preferedManager];
 		if (this.detectedManager) return COMMANDS[this.detectedManager];
 
 		for (const manager of PACKAGE_MANAGERS) {


### PR DESCRIPTION
## Pull Request Title
Prioritize package manager pnpm yarn npm

---

## Description
To optimize performance and ensure consistency, the CLI should automatically detect and prioritize the user's installed package manager in this order:

pnpm (highest priority - best performance)

yarn (fallback)

npm (last resort)

If pnpm is installed, all commands (e.g., installs, scripts) should use it; otherwise, fall back to yarn or npm.

---

## Related Issues
Closes #128 

---

## Changes Made
- [refactor: update package manager commands to use constants for install and build operations](https://github.com/deskree-inc/nanoservice-ts/commit/c58f57e7a087a193504aae678586b0746851446a)
- [fix: update regex for nanoservice name validation to allow only lowercase letters and dashes](https://github.com/deskree-inc/nanoservice-ts/commit/7ef7e2405f7238f6ad0837465767066656099724)

---

## Checklist
Detection:

Check for installed package managers in order: pnpm → yarn → npm.

Use which (Unix) / where (Windows) or programmatic checks (e.g., find-package-manager).

Execution:

Run all package-related commands (e.g., install, run build) with the highest-priority available manager.

Example: If pnpm exists, use pnpm install; otherwise, yarn install or npm install.

Feedback:

Log the detected manager (e.g., "Using pnpm (priority 1)").

Documentation:

Update CLI docs to explain priority logic and how to override (if needed).

---

## Screenshots/Media (if applicable)
_Add screenshots, GIFs, or other media to demonstrate the change._

---

## Notes for Reviewers
_Any additional context or notes for reviewers?_

---

Thank you for your contribution!
