### PR TITLE
Support for `--public` flag in Deploy Command

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nanoctl
 
+## 0.1.5
+
+### Patch Changes
+
+- allow deploy with public flag
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nanoctl",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"author": "Deskree Technologies Inc.",
 	"license": "Apache-2.0",
 	"description": "cli for nanoservice-ts",


### PR DESCRIPTION
This PR introduces a new `--public` flag to the `deploy` command in the CLI. When this flag is used, the deployed serverless application becomes publicly accessible **without requiring an access token**.

#### Key Changes

* Added support for the `--public` flag in the CLI's `deploy` command.
* When `--public` is set, the deployment process configures the serverless endpoint to be **open to the public**.
* Token-based access is **not required** for applications deployed with this flag.

#### Usage Example

```bash
npx nanoctl@latest deploy --public --name my-service
```

#### Notes

* This feature is intended for use cases where public access is required, such as public APIs, demos, or applications without authentication needs.
* By default, deployments remain private unless the `--public` flag is explicitly provided.
